### PR TITLE
Fixed a bug with GameInfoPresenter

### DIFF
--- a/app/src/main/java/fragment/GameInfoFragment.java
+++ b/app/src/main/java/fragment/GameInfoFragment.java
@@ -32,14 +32,6 @@ public class GameInfoFragment extends Fragment implements IGameInfoView {
     TextView destDeck;
     TextView trainDeck;
     GameInfoPresenter presenter;
-    private int buttonIndex = 0;
-    private String[] toastMessages = {"Updating opponent train cards",
-                                      "Updating opponent train car pieces",
-                                      "Updating opponent destination cards",
-                                      "Updating player scores",
-                                      "Changing turns"};
-
-
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/model/ClientModel.java
+++ b/app/src/main/java/model/ClientModel.java
@@ -54,6 +54,14 @@ public class ClientModel extends Observable {
         return currentGame.getPlayer(currentUser.getUsername()).getPlayerColor();
     }
 
+    public int getTrainDeckSize() {
+        return currentGame.getTrainCardDeck().size();
+    }
+
+    public int getDestDeckSize() {
+        return currentGame.getDestCardDeck().size();
+    }
+
     //for testing purposes
     public void setGameStart(boolean start) { startGame = start; }
 

--- a/app/src/main/java/model/UIFacade.java
+++ b/app/src/main/java/model/UIFacade.java
@@ -60,6 +60,14 @@ public class UIFacade implements IUIFacade {
         return ClientModel.getInstance().getPlayerPreSelectionTickets();
     }
 
+    public int getTrainDeckSize() {
+        return ClientModel.getInstance().getTrainDeckSize();
+    }
+
+    public int getDestDeckSize() {
+        return ClientModel.getInstance().getDestDeckSize();
+    }
+
     //This returns the error message if there is one, or null if there isn't
     private String processResults(Results results) {
         if(results != null && results.getSuccess()) {

--- a/app/src/main/java/presenter/GameInfoPresenter.java
+++ b/app/src/main/java/presenter/GameInfoPresenter.java
@@ -25,8 +25,13 @@ public class GameInfoPresenter implements IGameInfoPresenter, Observer {
     }
 
     public void initialUpdate(){
-        playersInfo = ClientModel.getInstance().getCurrentGame().getPlayers();
-        ClientModel.getInstance().notifyObservers(playersInfo);
+        int trainDeckSize = UIFacade.getInstance().getTrainDeckSize();
+        int destDeckSize = UIFacade.getInstance().getDestDeckSize();
+        playersInfo = UIFacade.getInstance().getCurrentGame().getPlayers();
+        view.updateTrainDeckInfo(trainDeckSize);
+        view.updateDestDeckInfo(destDeckSize);
+        view.updatePlayerInfo(playersInfo);
+
     }
 
     @Override


### PR DESCRIPTION
The GameInfoFragment was being populated correctly on game start, but if
you scrolled to the ChatFragment and then back to the GameInfoFragment,
nothing would be displayed. This fixes that problem